### PR TITLE
Fixed bug in SimpleMap causing JS to break

### DIFF
--- a/src/components/SimpleMap.js
+++ b/src/components/SimpleMap.js
@@ -4,8 +4,8 @@ import { GoogleMap, GoogleMapLoader } from 'react-google-maps';
 let mapRef;
 
 const SimpleMap = ({lat, long, markers, onMapClick}) => {
-  if (mapRef) {
-    mapRef.setCenter({lat: lat, lng: long});
+  if (mapRef && mapRef.props && mapRef.props.map) {
+    mapRef.props.map.setCenter({lat: lat, lng: long});
   }
   return (
   <section style={{
@@ -23,7 +23,7 @@ const SimpleMap = ({lat, long, markers, onMapClick}) => {
       }
       googleMapElement={
         <GoogleMap
-          ref={(map) => mapRef = map.props.map}
+          ref={(map) => mapRef = map}
           defaultZoom={10}
           defaultCenter={{ lat: lat, lng: long }}
           onClick={onMapClick}


### PR DESCRIPTION
Resolved issue where reference to map was set before map was instantiated